### PR TITLE
`silentCheckSsoRedirectUri` breaks React behaviour in Gatsby project

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -18,7 +18,7 @@ exports.wrapRootElement = ({ element }) => {
         promiseType: "native",
         onLoad: "check-sso",
         silentCheckSsoRedirectUri:
-          window.location.origin + "/silent-check-sso.html",
+          window.location.origin + "/silent-check-sso.xhtml",
       }}
       LoadingComponent={<Loading />}
     >

--- a/static/silent-check-sso.xhtml
+++ b/static/silent-check-sso.xhtml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+
+<head>
+  <script>parent.postMessage(location.href, location.origin)</script>
+</head>
+
+<body>
+</body>
+
+</html>


### PR DESCRIPTION
Hi @orelmax ,

This PR is related to the issue report opened [here](https://github.com/panz3r/react-keycloak/issues/36).

I downloaded your project and found out the following issues:
- Keycloak `silentCheckSsoRedirectUri` integration was incomplete, the `silent-check-sso.html` page was not correctly set up. (see [here](https://github.com/keycloak/keycloak-documentation/blob/master/securing_apps/topics/oidc/javascript-adapter.adoc) for the complete guide)
- There's an issue with making Gatsby serve static files (such as the aforementioned `silent-check-sso.html` ) so, following the workaround provided [here](https://github.com/gatsbyjs/gatsby/issues/13072#issuecomment-540068716), I implemented the `silent-check-sso.html` page as an `.xhtml` and made it work as expected.

Let me know if this helps you.